### PR TITLE
feat: avoid converting union into interleave

### DIFF
--- a/datafusion/core/src/physical_optimizer/projection_pushdown.rs
+++ b/datafusion/core/src/physical_optimizer/projection_pushdown.rs
@@ -528,7 +528,10 @@ fn try_pushdown_through_union(
         .map(|child| make_with_child(projection, &child))
         .collect::<Result<Vec<_>>>()?;
 
-    Ok(Some(Arc::new(UnionExec::new(new_children))))
+    Ok(Some(Arc::new(UnionExec::new_with_skip_interleave(
+        new_children,
+        union.skip_interleave(),
+    ))))
 }
 
 /// Some projection can't be pushed down left input or right input of hash join because filter or on need may need some columns that won't be used in later.

--- a/datafusion/core/src/physical_planner.rs
+++ b/datafusion/core/src/physical_planner.rs
@@ -917,10 +917,10 @@ impl DefaultPhysicalPlanner {
                     let filter = FilterExec::try_new(runtime_expr, physical_input)?;
                     Ok(Arc::new(filter.with_default_selectivity(selectivity)?))
                 }
-                LogicalPlan::Union(Union { inputs, schema: _ }) => {
+                LogicalPlan::Union(Union { inputs, schema: _, skip_interleave }) => {
                     let physical_plans = self.create_initial_plan_multi(inputs.iter().map(|lp| lp.as_ref()), session_state).await?;
 
-                    Ok(Arc::new(UnionExec::new(physical_plans)))
+                    Ok(Arc::new(UnionExec::new_with_skip_interleave(physical_plans, *skip_interleave)))
                 }
                 LogicalPlan::Repartition(Repartition {
                     input,

--- a/datafusion/expr/src/logical_plan/builder.rs
+++ b/datafusion/expr/src/logical_plan/builder.rs
@@ -564,6 +564,15 @@ impl LogicalPlanBuilder {
             .map(Self::from)
     }
 
+    /// Apply a union with skip interlave, preserving duplicate rows
+    pub fn union_with_skip_interleave(
+        self,
+        plan: LogicalPlan,
+        skip_interleave: bool,
+    ) -> Result<Self> {
+        union_with_skip_interleave(self.plan, plan, skip_interleave).map(Self::from)
+    }
+
     /// Apply a union, preserving duplicate rows
     pub fn union(self, plan: LogicalPlan) -> Result<Self> {
         union(self.plan, plan).map(Self::from)
@@ -1303,6 +1312,15 @@ pub fn project_with_column_index(
 
 /// Union two logical plans.
 pub fn union(left_plan: LogicalPlan, right_plan: LogicalPlan) -> Result<LogicalPlan> {
+    union_with_skip_interleave(left_plan, right_plan, false)
+}
+
+/// Union two logical plans with skip interleave.
+pub fn union_with_skip_interleave(
+    left_plan: LogicalPlan,
+    right_plan: LogicalPlan,
+    skip_interleave: bool,
+) -> Result<LogicalPlan> {
     let left_col_num = left_plan.schema().fields().len();
 
     // check union plan length same.
@@ -1365,6 +1383,7 @@ pub fn union(left_plan: LogicalPlan, right_plan: LogicalPlan) -> Result<LogicalP
     Ok(LogicalPlan::Union(Union {
         inputs,
         schema: Arc::new(union_schema),
+        skip_interleave,
     }))
 }
 

--- a/datafusion/optimizer/src/eliminate_one_union.rs
+++ b/datafusion/optimizer/src/eliminate_one_union.rs
@@ -110,6 +110,7 @@ mod tests {
         let single_union_plan = LogicalPlan::Union(Union {
             inputs: vec![Arc::new(table_plan)],
             schema,
+            skip_interleave: false,
         });
 
         let expected = "TableScan: table";

--- a/datafusion/optimizer/src/plan_signature.rs
+++ b/datafusion/optimizer/src/plan_signature.rs
@@ -114,6 +114,7 @@ mod tests {
         let five_node_plan = Arc::new(LogicalPlan::Union(datafusion_expr::Union {
             inputs: vec![two_node_plan.clone(), two_node_plan],
             schema,
+            skip_interleave: false,
         }));
 
         assert_eq!(5, get_node_number(&five_node_plan).get());

--- a/datafusion/optimizer/src/propagate_empty_relation.rs
+++ b/datafusion/optimizer/src/propagate_empty_relation.rs
@@ -119,6 +119,7 @@ impl OptimizerRule for PropagateEmptyRelation {
                     return Ok(Some(LogicalPlan::Union(Union {
                         inputs: new_inputs,
                         schema: union.schema.clone(),
+                        skip_interleave: union.skip_interleave,
                     })));
                 }
             }

--- a/datafusion/optimizer/src/push_down_filter.rs
+++ b/datafusion/optimizer/src/push_down_filter.rs
@@ -777,6 +777,7 @@ impl OptimizerRule for PushDownFilter {
                 LogicalPlan::Union(Union {
                     inputs,
                     schema: plan.schema().clone(),
+                    skip_interleave: union.skip_interleave,
                 })
             }
             LogicalPlan::Aggregate(agg) => {

--- a/datafusion/optimizer/src/push_down_limit.rs
+++ b/datafusion/optimizer/src/push_down_limit.rs
@@ -142,6 +142,7 @@ impl OptimizerRule for PushDownLimit {
                 let union = LogicalPlan::Union(Union {
                     inputs: new_inputs,
                     schema: union.schema.clone(),
+                    skip_interleave: union.skip_interleave,
                 });
                 plan.with_new_exprs(plan.expressions(), vec![union])
                     .map(Some)


### PR DESCRIPTION
This is a temporary PR just for @alamb and me to discuss our approach. We do not plan to merge this into any branch/repo (yet)

This related to IOX WIP PR https://github.com/influxdata/influxdb_iox/pull/10540

## Which issue does this PR close?

Currently, DF always replaces `Union` with `Interleave` if the the operators under the union can interleave  which means they have same `hash partition`.  And this happens if they are aggregate as the plan below

**Logical plan of `SHOW TAG VALUES WITH KEY = "tag0";`  with aggregation under union**

```SQL
 Sort: iox::measurement ASC NULLS LAST, key ASC NULLS LAST, value ASC NULLS LAST
   Union
     Projection: Dictionary(Int32, Utf8("m0")) AS iox::measurement, Dictionary(Int32, Utf8("tag0")) AS key, m0.tag0 AS value
       Aggregate: groupBy=[[m0.tag0]], aggr=[[]]
         TableScan: m0 projection=[tag0], full_filters=[m0.time >= TimestampNanosecond(631152000000000000, Some("UTC"))]
     Projection: Dictionary(Int32, Utf8("m1")) AS iox::measurement, Dictionary(Int32, Utf8("tag0")) AS key, m1.tag0 AS value
       Aggregate: groupBy=[[m1.tag0]], aggr=[[]]
          TableScan: m1 projection=[tag0], full_filters=[m1.time >= TimestampNanosecond(631152000000000000, Some("UTC"))]
```

**Physical plan where the Union was replaced with Interleave and as a result/consequence the Sort was not pushed down**

```SQL
SortPreservingMergeExec: [iox::measurement@0 ASC NULLS LAST,key@1 ASC NULLS LAST,value@2 ASC NULLS LAST]
   SortExec: expr=[iox::measurement@0 ASC NULLS LAST,key@1 ASC NULLS LAST,value@2 ASC NULLS LAST]
     InterleaveExec   -- Union is now Interleave and thus sort is not pushed down (which makes sense in case of interleave but not waht we want)
       ProjectionExec: expr=[m0 as iox::measurement, tag0 as key, tag0@0 as value]
         AggregateExec: mode=FinalPartitioned, gby=[tag0@0 as tag0], aggr=[]
           CoalesceBatchesExec: target_batch_size=8192
             RepartitionExec: partitioning=Hash([tag0@0], 4), input_partitions=4
               AggregateExec: mode=Partial, gby=[tag0@0 as tag0], aggr=[]
                 RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
                   ProjectionExec: expr=[tag0@0 as tag0]
                     CoalesceBatchesExec: target_batch_size=8192
                       FilterExec: time@1 >= 631152000000000000
                         ParquetExec: file_groups={1 group: [[1/1/1/00000000-0000-0000-0000-000000000000.parquet]]}, projection=[tag0, time], predicate=time@5 >= 631152000000000000, pruning_predicate=time_max@0 >= 631152000000000000, required_guarantees=[]
       ProjectionExec: expr=[m1 as iox::measurement, tag0 as key, tag0@0 as value]
         AggregateExec: mode=FinalPartitioned, gby=[tag0@0 as tag0], aggr=[], ordering_mode=Sorted
           CoalesceBatchesExec: target_batch_size=8192
             RepartitionExec: partitioning=Hash([tag0@0], 4), input_partitions=4, preserve_order=true, sort_exprs=tag0@0 ASC
               AggregateExec: mode=Partial, gby=[tag0@0 as tag0], aggr=[], ordering_mode=Sorted
                 RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
                   ProjectionExec: expr=[tag0@0 as tag0]
                     CoalesceBatchesExec: target_batch_size=8192
                       FilterExec: time@1 >= 631152000000000000
                         ParquetExec: file_groups={1 group: [[1/1/1/00000000-0000-0000-0000-000000000001.parquet]]}, projection=[tag0, time], output_ordering=[tag0@0 ASC, time@1 ASC], predicate=time@4 >= 631152000000000000, pruning_predicate=time_max@0 >= 631152000000000000, required_guarantees=[]
```

### If we do not let Union be replaced with Interleave

**Physical plan will have Sort pushed down**

```SQL
 SortPreservingMergeExec: [iox::measurement@0 ASC NULLS LAST,key@1 ASC NULLS LAST,value@2 ASC NULLS LAST]
   UnionExec  -- Union stil still union
     SortExec: expr=[iox::measurement@0 ASC NULLS LAST,key@1 ASC NULLS LAST,value@2 ASC NULLS LAST]
       ProjectionExec: expr=[m0 as iox::measurement, tag0 as key, tag0@0 as value]
         AggregateExec: mode=FinalPartitioned, gby=[tag0@0 as tag0], aggr=[]
           CoalesceBatchesExec: target_batch_size=8192
             RepartitionExec: partitioning=Hash([tag0@0], 4), input_partitions=4
               AggregateExec: mode=Partial, gby=[tag0@0 as tag0], aggr=[]
                 RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
                   ProjectionExec: expr=[tag0@0 as tag0]
                     CoalesceBatchesExec: target_batch_size=8192
                       FilterExec: time@1 >= 631152000000000000
                         ParquetExec: file_groups={1 group: [[1/1/1/00000000-0000-0000-0000-000000000000.parquet]]}, projection=[tag0, time], predicate=time@5 >= 631152000000000000, pruning_predicate=time_max@0 >= 631152000000000000, required_guarantees=[]
     SortExec: expr=[iox::measurement@0 ASC NULLS LAST,key@1 ASC NULLS LAST,value@2 ASC NULLS LAST]
       ProjectionExec: expr=[m1 as iox::measurement, tag0 as key, tag0@0 as value]
         AggregateExec: mode=FinalPartitioned, gby=[tag0@0 as tag0], aggr=[], ordering_mode=Sorted
           CoalesceBatchesExec: target_batch_size=8192
             RepartitionExec: partitioning=Hash([tag0@0], 4), input_partitions=4, preserve_order=true, sort_exprs=tag0@0 ASC
               AggregateExec: mode=Partial, gby=[tag0@0 as tag0], aggr=[], ordering_mode=Sorted
                 RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
                   ProjectionExec: expr=[tag0@0 as tag0]
                     CoalesceBatchesExec: target_batch_size=8192
                       FilterExec: time@1 >= 631152000000000000
                         ParquetExec: file_groups={1 group: [[1/1/1/00000000-0000-0000-0000-000000000001.parquet]]}, projection=[tag0, time], output_ordering=[tag0@0 ASC, time@1 ASC], predicate=time@4 >= 631152000000000000, pruning_predicate=time_max@0 >= 631152000000000000, required_guarantees=[]
```

**And we will be able to replace `SortPreservingMerge` with `ProgresiveEval`**

```SQL
ProgressiveEvalExec: input_ranges=[(Utf8("m0"), Utf8("m0")), (Utf8("m1"), Utf8("m1")), (Utf8("m2"), Utf8("m2")), (Utf8("m3"), Utf8("m3")), (Utf8("select_test"), Utf8("select_test"))]
   UnionExec
     SortPreservingMergeExec: [iox::measurement@0 ASC NULLS LAST,key@1 ASC NULLS LAST,value@2 ASC NULLS LAST]
       SortExec: expr=[iox::measurement@0 ASC NULLS LAST,key@1 ASC NULLS LAST,value@2 ASC NULLS LAST]
         ProjectionExec: expr=[m0 as iox::measurement, tag0 as key, tag0@0 as value]
           AggregateExec: mode=FinalPartitioned, gby=[tag0@0 as tag0], aggr=[]
             CoalesceBatchesExec: target_batch_size=8192
               RepartitionExec: partitioning=Hash([tag0@0], 4), input_partitions=4
                 AggregateExec: mode=Partial, gby=[tag0@0 as tag0], aggr=[]
                   RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
                     ProjectionExec: expr=[tag0@0 as tag0]
                       CoalesceBatchesExec: target_batch_size=8192
                         FilterExec: time@1 >= 631152000000000000
                           ParquetExec: file_groups={1 group: [[1/1/1/00000000-0000-0000-0000-000000000000.parquet]]}, projection=[tag0, time], predicate=time@5 >= 631152000000000000, pruning_predicate=time_max@0 >= 631152000000000000, required_guarantees=[]
     SortPreservingMergeExec: [iox::measurement@0 ASC NULLS LAST,key@1 ASC NULLS LAST,value@2 ASC NULLS LAST]
       SortExec: expr=[iox::measurement@0 ASC NULLS LAST,key@1 ASC NULLS LAST,value@2 ASC NULLS LAST]
         ProjectionExec: expr=[m1 as iox::measurement, tag0 as key, tag0@0 as value]
           AggregateExec: mode=FinalPartitioned, gby=[tag0@0 as tag0], aggr=[], ordering_mode=Sorted
             CoalesceBatchesExec: target_batch_size=8192
               RepartitionExec: partitioning=Hash([tag0@0], 4), input_partitions=4, preserve_order=true, sort_exprs=tag0@0 ASC
                 AggregateExec: mode=Partial, gby=[tag0@0 as tag0], aggr=[], ordering_mode=Sorted
                   RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
                     ProjectionExec: expr=[tag0@0 as tag0]
                       CoalesceBatchesExec: target_batch_size=8192
                         FilterExec: time@1 >= 631152000000000000
                           ParquetExec: file_groups={1 group: [[1/1/1/00000000-0000-0000-0000-000000000001.parquet]]}, projection=[tag0, time], output_ordering=[tag0@0 ASC, time@1 ASC], predicate=time@4 >= 631152000000000000, pruning_predicate=time_max@0 >= 631152000000000000, required_guarantees=[]
```
