### PR TITLE
WIP(iox-10350): patched df upgrade 2024-03-31 (ver 37.0.0)

### DIFF
--- a/datafusion/expr/src/type_coercion/functions.rs
+++ b/datafusion/expr/src/type_coercion/functions.rs
@@ -311,17 +311,25 @@ fn coerced_from<'a>(
     type_from: &'a DataType,
 ) -> Option<DataType> {
     use self::DataType::*;
-
-    match type_into {
+    // match Dictionary first
+    match (type_into, type_from) {
+        // coerced dictionary first
+        (cur_type, Dictionary(_, value_type)) | (Dictionary(_, value_type), cur_type)
+            if coerced_from(cur_type, value_type).is_some() =>
+        {
+            Some(type_into.clone())
+        }
         // coerced into type_into
-        Int8 if matches!(type_from, Null | Int8) => Some(type_into.clone()),
-        Int16 if matches!(type_from, Null | Int8 | Int16 | UInt8) => {
+        (Int8, _) if matches!(type_from, Null | Int8) => Some(type_into.clone()),
+        (Int16, _) if matches!(type_from, Null | Int8 | Int16 | UInt8) => {
             Some(type_into.clone())
         }
-        Int32 if matches!(type_from, Null | Int8 | Int16 | Int32 | UInt8 | UInt16) => {
+        (Int32, _)
+            if matches!(type_from, Null | Int8 | Int16 | Int32 | UInt8 | UInt16) =>
+        {
             Some(type_into.clone())
         }
-        Int64
+        (Int64, _)
             if matches!(
                 type_from,
                 Null | Int8 | Int16 | Int32 | Int64 | UInt8 | UInt16 | UInt32
@@ -329,15 +337,17 @@ fn coerced_from<'a>(
         {
             Some(type_into.clone())
         }
-        UInt8 if matches!(type_from, Null | UInt8) => Some(type_into.clone()),
-        UInt16 if matches!(type_from, Null | UInt8 | UInt16) => Some(type_into.clone()),
-        UInt32 if matches!(type_from, Null | UInt8 | UInt16 | UInt32) => {
+        (UInt8, _) if matches!(type_from, Null | UInt8) => Some(type_into.clone()),
+        (UInt16, _) if matches!(type_from, Null | UInt8 | UInt16) => {
             Some(type_into.clone())
         }
-        UInt64 if matches!(type_from, Null | UInt8 | UInt16 | UInt32 | UInt64) => {
+        (UInt32, _) if matches!(type_from, Null | UInt8 | UInt16 | UInt32) => {
             Some(type_into.clone())
         }
-        Float32
+        (UInt64, _) if matches!(type_from, Null | UInt8 | UInt16 | UInt32 | UInt64) => {
+            Some(type_into.clone())
+        }
+        (Float32, _)
             if matches!(
                 type_from,
                 Null | Int8
@@ -353,7 +363,7 @@ fn coerced_from<'a>(
         {
             Some(type_into.clone())
         }
-        Float64
+        (Float64, _)
             if matches!(
                 type_from,
                 Null | Int8
@@ -371,7 +381,7 @@ fn coerced_from<'a>(
         {
             Some(type_into.clone())
         }
-        Timestamp(TimeUnit::Nanosecond, None)
+        (Timestamp(TimeUnit::Nanosecond, None), _)
             if matches!(
                 type_from,
                 Null | Timestamp(_, None) | Date32 | Utf8 | LargeUtf8
@@ -379,23 +389,27 @@ fn coerced_from<'a>(
         {
             Some(type_into.clone())
         }
-        Interval(_) if matches!(type_from, Utf8 | LargeUtf8) => Some(type_into.clone()),
+        (Interval(_), _) if matches!(type_from, Utf8 | LargeUtf8) => {
+            Some(type_into.clone())
+        }
         // Any type can be coerced into strings
-        Utf8 | LargeUtf8 => Some(type_into.clone()),
-        Null if can_cast_types(type_from, type_into) => Some(type_into.clone()),
+        (Utf8 | LargeUtf8, _) => Some(type_into.clone()),
+        (Null, _) if can_cast_types(type_from, type_into) => Some(type_into.clone()),
 
-        List(_) if matches!(type_from, FixedSizeList(_, _)) => Some(type_into.clone()),
+        (List(_), _) if matches!(type_from, FixedSizeList(_, _)) => {
+            Some(type_into.clone())
+        }
 
         // Only accept list and largelist with the same number of dimensions unless the type is Null.
         // List or LargeList with different dimensions should be handled in TypeSignature or other places before this
-        List(_) | LargeList(_)
+        (List(_) | LargeList(_), _)
             if datafusion_common::utils::base_type(type_from).eq(&Null)
                 || list_ndims(type_from) == list_ndims(type_into) =>
         {
             Some(type_into.clone())
         }
         // should be able to coerce wildcard fixed size list to non wildcard fixed size list
-        FixedSizeList(f_into, FIXED_SIZE_LIST_WILDCARD) => match type_from {
+        (FixedSizeList(f_into, FIXED_SIZE_LIST_WILDCARD), _) => match type_from {
             FixedSizeList(f_from, size_from) => {
                 match coerced_from(f_into.data_type(), f_from.data_type()) {
                     Some(data_type) if &data_type != f_into.data_type() => {
@@ -410,7 +424,7 @@ fn coerced_from<'a>(
             _ => None,
         },
 
-        Timestamp(unit, Some(tz)) if tz.as_ref() == TIMEZONE_WILDCARD => {
+        (Timestamp(unit, Some(tz)), _) if tz.as_ref() == TIMEZONE_WILDCARD => {
             match type_from {
                 Timestamp(_, Some(from_tz)) => {
                     Some(Timestamp(unit.clone(), Some(from_tz.clone())))
@@ -422,7 +436,7 @@ fn coerced_from<'a>(
                 _ => None,
             }
         }
-        Timestamp(_, Some(_))
+        (Timestamp(_, Some(_)), _)
             if matches!(
                 type_from,
                 Null | Timestamp(_, _) | Date32 | Utf8 | LargeUtf8
@@ -430,7 +444,6 @@ fn coerced_from<'a>(
         {
             Some(type_into.clone())
         }
-
         // More coerce rules.
         // Note that not all rules in `comparison_coercion` can be reused here.
         // For example, all numeric types can be coerced into Utf8 for comparison,

--- a/datafusion/optimizer/src/analyzer/function_rewrite.rs
+++ b/datafusion/optimizer/src/analyzer/function_rewrite.rs
@@ -21,9 +21,10 @@ use super::AnalyzerRule;
 use datafusion_common::config::ConfigOptions;
 use datafusion_common::tree_node::{Transformed, TreeNodeRewriter};
 use datafusion_common::{DFSchema, Result};
+use datafusion_expr::expr::{Exists, InSubquery};
 use datafusion_expr::expr_rewriter::{rewrite_preserving_name, FunctionRewrite};
 use datafusion_expr::utils::merge_schema;
-use datafusion_expr::{Expr, LogicalPlan};
+use datafusion_expr::{Expr, LogicalPlan, Subquery};
 use std::sync::Arc;
 
 /// Analyzer rule that invokes [`FunctionRewrite`]s on expressions
@@ -45,52 +46,66 @@ impl AnalyzerRule for ApplyFunctionRewrites {
     }
 
     fn analyze(&self, plan: LogicalPlan, options: &ConfigOptions) -> Result<LogicalPlan> {
-        self.analyze_internal(&plan, options)
+        analyze_internal(&plan, &self.function_rewrites, options)
     }
 }
 
-impl ApplyFunctionRewrites {
-    fn analyze_internal(
-        &self,
-        plan: &LogicalPlan,
-        options: &ConfigOptions,
-    ) -> Result<LogicalPlan> {
-        // optimize child plans first
-        let new_inputs = plan
-            .inputs()
-            .iter()
-            .map(|p| self.analyze_internal(p, options))
-            .collect::<Result<Vec<_>>>()?;
+fn analyze_internal(
+    plan: &LogicalPlan,
+    function_rewrites: &[Arc<dyn FunctionRewrite + Send + Sync>],
+    options: &ConfigOptions,
+) -> Result<LogicalPlan> {
+    // optimize child plans first
+    let new_inputs = plan
+        .inputs()
+        .iter()
+        .map(|p| analyze_internal(p, function_rewrites, options))
+        .collect::<Result<Vec<_>>>()?;
 
-        // get schema representing all available input fields. This is used for data type
-        // resolution only, so order does not matter here
-        let mut schema = merge_schema(new_inputs.iter().collect());
+    // get schema representing all available input fields. This is used for data type
+    // resolution only, so order does not matter here
+    let mut schema = merge_schema(new_inputs.iter().collect());
 
-        if let LogicalPlan::TableScan(ts) = plan {
-            let source_schema =
-                DFSchema::try_from_qualified_schema(&ts.table_name, &ts.source.schema())?;
-            schema.merge(&source_schema);
-        }
-
-        let mut expr_rewrite = OperatorToFunctionRewriter {
-            function_rewrites: &self.function_rewrites,
-            options,
-            schema: &schema,
-        };
-
-        let new_expr = plan
-            .expressions()
-            .into_iter()
-            .map(|expr| {
-                // ensure names don't change:
-                // https://github.com/apache/arrow-datafusion/issues/3555
-                rewrite_preserving_name(expr, &mut expr_rewrite)
-            })
-            .collect::<Result<Vec<_>>>()?;
-
-        plan.with_new_exprs(new_expr, new_inputs)
+    if let LogicalPlan::TableScan(ts) = plan {
+        let source_schema = DFSchema::try_from_qualified_schema(
+            ts.table_name.clone(),
+            &ts.source.schema(),
+        )?;
+        schema.merge(&source_schema);
     }
+
+    let mut expr_rewrite = OperatorToFunctionRewriter {
+        function_rewrites,
+        options,
+        schema: &schema,
+    };
+
+    let new_expr = plan
+        .expressions()
+        .into_iter()
+        .map(|expr| {
+            // ensure names don't change:
+            // https://github.com/apache/arrow-datafusion/issues/3555
+            rewrite_preserving_name(expr, &mut expr_rewrite)
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    plan.with_new_exprs(new_expr, new_inputs)
 }
+
+fn rewrite_subquery(
+    mut subquery: Subquery,
+    function_rewrites: &[Arc<dyn FunctionRewrite + Send + Sync>],
+    options: &ConfigOptions,
+) -> Result<Subquery> {
+    subquery.subquery = Arc::new(analyze_internal(
+        &subquery.subquery,
+        function_rewrites,
+        options,
+    )?);
+    Ok(subquery)
+}
+
 struct OperatorToFunctionRewriter<'a> {
     function_rewrites: &'a [Arc<dyn FunctionRewrite + Send + Sync>],
     options: &'a ConfigOptions,
@@ -110,6 +125,40 @@ impl<'a> TreeNodeRewriter for OperatorToFunctionRewriter<'a> {
             }
             expr = result.data
         }
+
+        // recurse into subqueries if needed
+        let expr = match expr {
+            Expr::ScalarSubquery(subquery) => Expr::ScalarSubquery(rewrite_subquery(
+                subquery,
+                self.function_rewrites,
+                self.options,
+            )?),
+
+            Expr::Exists(Exists { subquery, negated }) => Expr::Exists(Exists {
+                subquery: rewrite_subquery(
+                    subquery,
+                    self.function_rewrites,
+                    self.options,
+                )?,
+                negated,
+            }),
+
+            Expr::InSubquery(InSubquery {
+                expr,
+                subquery,
+                negated,
+            }) => Expr::InSubquery(InSubquery {
+                expr,
+                subquery: rewrite_subquery(
+                    subquery,
+                    self.function_rewrites,
+                    self.options,
+                )?,
+                negated,
+            }),
+
+            expr => expr,
+        };
 
         Ok(if transformed {
             Transformed::yes(expr)

--- a/datafusion/sql/src/expr/mod.rs
+++ b/datafusion/sql/src/expr/mod.rs
@@ -593,6 +593,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         }
     }
 
+    /// Parses a struct(..) expression
     fn parse_struct(
         &self,
         values: Vec<SQLExpr>,
@@ -603,6 +604,25 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         if !fields.is_empty() {
             return not_impl_err!("Struct fields are not supported yet");
         }
+
+        if values
+            .iter()
+            .any(|value| matches!(value, SQLExpr::Named { .. }))
+        {
+            self.create_named_struct(values, input_schema, planner_context)
+        } else {
+            self.create_struct(values, input_schema, planner_context)
+        }
+    }
+
+    // Handles a call to struct(...) where the arguments are named. For example
+    // `struct (v as foo, v2 as bar)` by creating a call to the `named_struct` function
+    fn create_named_struct(
+        &self,
+        values: Vec<SQLExpr>,
+        input_schema: &DFSchema,
+        planner_context: &mut PlannerContext,
+    ) -> Result<Expr> {
         let args = values
             .into_iter()
             .enumerate()
@@ -643,6 +663,34 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
 
         Ok(Expr::ScalarFunction(ScalarFunction::new_udf(
             named_struct_func,
+            args,
+        )))
+    }
+
+    // Handles a call to struct(...) where the arguments are not named. For example
+    // `struct (v, v2)` by creating a call to the `struct` function
+    // which will create a struct with fields named `c0`, `c1`, etc.
+    fn create_struct(
+        &self,
+        values: Vec<SQLExpr>,
+        input_schema: &DFSchema,
+        planner_context: &mut PlannerContext,
+    ) -> Result<Expr> {
+        let args = values
+            .into_iter()
+            .map(|value| {
+                self.sql_expr_to_logical_expr(value, input_schema, planner_context)
+            })
+            .collect::<Result<Vec<_>>>()?;
+        let struct_func = self
+            .context_provider
+            .get_function_meta("struct")
+            .ok_or_else(|| {
+                internal_datafusion_err!("Unable to find expected 'struct' function")
+            })?;
+
+        Ok(Expr::ScalarFunction(ScalarFunction::new_udf(
+            struct_func,
             args,
         )))
     }

--- a/datafusion/sqllogictest/test_files/explain.slt
+++ b/datafusion/sqllogictest/test_files/explain.slt
@@ -390,8 +390,8 @@ query TT
 explain select struct(1, 2.3, 'abc');
 ----
 logical_plan
-Projection: Struct({c0:1,c1:2.3,c2:abc}) AS named_struct(Utf8("c0"),Int64(1),Utf8("c1"),Float64(2.3),Utf8("c2"),Utf8("abc"))
+Projection: Struct({c0:1,c1:2.3,c2:abc}) AS struct(Int64(1),Float64(2.3),Utf8("abc"))
 --EmptyRelation
 physical_plan
-ProjectionExec: expr=[{c0:1,c1:2.3,c2:abc} as named_struct(Utf8("c0"),Int64(1),Utf8("c1"),Float64(2.3),Utf8("c2"),Utf8("abc"))]
+ProjectionExec: expr=[{c0:1,c1:2.3,c2:abc} as struct(Int64(1),Float64(2.3),Utf8("abc"))]
 --PlaceholderRowExec

--- a/datafusion/sqllogictest/test_files/scalar.slt
+++ b/datafusion/sqllogictest/test_files/scalar.slt
@@ -1779,6 +1779,46 @@ SELECT COALESCE(NULL, 'test')
 ----
 test
 
+
+statement ok
+create table test1 as values (arrow_cast('foo', 'Dictionary(Int32, Utf8)')), (null);
+
+# test coercion string
+query ?
+select  coalesce(column1, 'none_set') from test1;
+----
+foo
+none_set
+
+# test coercion Int
+query I
+select coalesce(34, arrow_cast(123, 'Dictionary(Int32, Int8)'));
+----
+34
+
+# test with Int
+query I
+select coalesce(arrow_cast(123, 'Dictionary(Int32, Int8)'),34);
+----
+123
+
+# test with null
+query I
+select coalesce(null, 34, arrow_cast(123, 'Dictionary(Int32, Int8)'));
+----
+34
+
+# test with null
+query T
+select  coalesce(null, column1, 'none_set') from test1;
+----
+foo
+none_set
+
+statement ok
+drop table test1
+
+
 statement ok
 CREATE TABLE test(
   c1 INT,
@@ -2162,5 +2202,3 @@ query I
 select strpos('joséésoj', arrow_cast(null, 'Utf8'));
 ----
 NULL
-
-

--- a/datafusion/sqllogictest/test_files/struct.slt
+++ b/datafusion/sqllogictest/test_files/struct.slt
@@ -85,10 +85,10 @@ query TT
 explain select struct(a, b, c) from values;
 ----
 logical_plan
-Projection: named_struct(Utf8("c0"), values.a, Utf8("c1"), values.b, Utf8("c2"), values.c)
+Projection: struct(values.a, values.b, values.c)
 --TableScan: values projection=[a, b, c]
 physical_plan
-ProjectionExec: expr=[named_struct(c0, a@0, c1, b@1, c2, c@2) as named_struct(Utf8("c0"),values.a,Utf8("c1"),values.b,Utf8("c2"),values.c)]
+ProjectionExec: expr=[struct(a@0, b@1, c@2) as struct(values.a,values.b,values.c)]
 --MemoryExec: partitions=1, partition_sizes=[1]
 
 # error on 0 arguments

--- a/datafusion/sqllogictest/test_files/subquery.slt
+++ b/datafusion/sqllogictest/test_files/subquery.slt
@@ -1060,3 +1060,58 @@ logical_plan
 Projection: t.a / Int64(2)Int64(2)t.a AS t.a / Int64(2), t.a / Int64(2)Int64(2)t.a AS t.a / Int64(2) + Int64(1)
 --Projection: t.a / Int64(2) AS t.a / Int64(2)Int64(2)t.a
 ----TableScan: t projection=[a]
+
+###
+## Ensure that operators are rewritten in subqueries
+###
+
+statement ok
+create table foo(x int) as values (1);
+
+# Show input data
+query ?
+select struct(1, 'b')
+----
+{c0: 1, c1: b}
+
+
+query T
+select (select struct(1, 'b')['c1']);
+----
+b
+
+query T
+select 'foo' || (select struct(1, 'b')['c1']);
+----
+foob
+
+query I
+SELECT  * FROM (VALUES (1), (2))
+WHERE column1  IN (SELECT struct(1, 'b')['c0']);
+----
+1
+
+# also add an expression so the subquery is the output expr
+query I
+SELECT  * FROM (VALUES (1), (2))
+WHERE 1+2 = 3 AND column1  IN (SELECT struct(1, 'b')['c0']);
+----
+1
+
+
+query I
+SELECT  * FROM foo
+WHERE EXISTS (SELECT * FROM (values (1)) WHERE column1 = foo.x AND struct(1, 'b')['c0'] = 1);
+----
+1
+
+# also add an expression so the subquery is the output expr
+query I
+SELECT  * FROM foo
+WHERE 1+2 = 3 AND EXISTS (SELECT * FROM (values (1)) WHERE column1 = foo.x AND struct(1, 'b')['c0'] = 1);
+----
+1
+
+
+statement ok
+drop table foo;

--- a/docs/source/user-guide/sql/scalar_functions.md
+++ b/docs/source/user-guide/sql/scalar_functions.md
@@ -3336,6 +3336,16 @@ select * from t;
 | 3 | 4 |
 +---+---+
 
+-- use default names `c0`, `c1`
+❯ select struct(a, b) from t;
++-----------------+
+| struct(t.a,t.b) |
++-----------------+
+| {c0: 1, c1: 2}  |
+| {c0: 3, c1: 4}  |
++-----------------+
+
+-- name the first field `field_a`
 select struct(a as field_a, b) from t;
 +--------------------------------------------------+
 | named_struct(Utf8("field_a"),t.a,Utf8("c1"),t.b) |


### PR DESCRIPTION
⚠️ This will not be merged. ⚠️ 

## What's in this branch:

1. Bringing us up to datafusion 37.0.0
     * EOD on 2024-03-31 is this commit:
        ```
        commit cd7a00b08309f7229073e4bba686d6271726ab1c
        Author: wiedld <wiedld@users.noreply.github.com>
        Date:   Sun Mar 31 05:09:06 2024 -0700

            fix(9870): common expression elimination optimization, should always re-find the correct expression during re-write. (#9871)
        ```


1. PATCH: add the named struct patch
    ```
    commit 66f4fcb4664fc797ffb046d5b2ebcfca65ba4cd7
    Author: Andrew Lamb <andrew@nerdnetworks.org>
    Date:   Tue Apr 2 17:21:02 2024 -0400

        Use `struct` instead of `named_struct` when there are no aliases (#9897)
    ```

1. PATCH: include the patch request ([per slack](https://influxdata.slack.com/archives/CRK9M8L5Q/p1712153458263349?thread_ts=1712132260.264339&cid=CRK9M8L5Q)) for the [upstream coalesce bug](https://github.com/apache/arrow-datafusion/issues/9925).
    ```
    commit f0eec349a1abed14bcb2ee8a9fbf98bbb19b8f9a (HEAD -> iox-10350/df-upgrade-2024-03-31)
    Author: Lordworms <48054792+Lordworms@users.noreply.github.com>
    Date:   Fri Apr 5 15:57:48 2024 -0500

        coercion vec[Dictionary, Utf8] to Dictionary for coalesce function (#9958)
    ```

1. PATCH: patch for the function re-writer, visiting subqueries within expressions.
    ```
    commit e8de1c612a986ae4b0348ce0a9d92f08d93c258c
    Author: Andrew Lamb <andrew@nerdnetworks.org>
    Date:   Wed Apr 10 11:14:02 2024 -0400

        fix NamedStructField should be rewritten in OperatorToFunction in subquery
    ```