### PR TITLE
WIP(iox-10891): patched df upgrade 202-05-13

### DIFF
--- a/datafusion/core/src/datasource/listing/helpers.rs
+++ b/datafusion/core/src/datasource/listing/helpers.rs
@@ -84,7 +84,6 @@ pub fn expr_applicable_for_cols(col_names: &[String], expr: &Expr) -> bool {
             | Expr::Exists { .. }
             | Expr::InSubquery(_)
             | Expr::ScalarSubquery(_)
-            | Expr::GetIndexedField { .. }
             | Expr::GroupingSet(_)
             | Expr::Case { .. } => Ok(TreeNodeRecursion::Continue),
 

--- a/datafusion/core/src/physical_planner.rs
+++ b/datafusion/core/src/physical_planner.rs
@@ -83,8 +83,7 @@ use datafusion_common::{
 use datafusion_expr::dml::CopyTo;
 use datafusion_expr::expr::{
     self, AggregateFunction, AggregateFunctionDefinition, Alias, Between, BinaryExpr,
-    Cast, GetFieldAccess, GetIndexedField, GroupingSet, InList, Like, TryCast,
-    WindowFunction,
+    Cast, GroupingSet, InList, Like, TryCast, WindowFunction,
 };
 use datafusion_expr::expr_rewriter::unnormalize_cols;
 use datafusion_expr::expr_vec_fmt;
@@ -215,29 +214,6 @@ fn create_physical_name(e: &Expr, is_first_expr: bool) -> Result<String> {
         Expr::IsNotUnknown(expr) => {
             let expr = create_physical_name(expr, false)?;
             Ok(format!("{expr} IS NOT UNKNOWN"))
-        }
-        Expr::GetIndexedField(GetIndexedField { expr: _, field }) => {
-            match field {
-                GetFieldAccess::NamedStructField { name: _ } => {
-                    unreachable!(
-                        "NamedStructField should have been rewritten in OperatorToFunction"
-                    )
-                }
-                GetFieldAccess::ListIndex { key: _ } => {
-                    unreachable!(
-                        "ListIndex should have been rewritten in OperatorToFunction"
-                    )
-                }
-                GetFieldAccess::ListRange {
-                    start: _,
-                    stop: _,
-                    stride: _,
-                } => {
-                    unreachable!(
-                        "ListRange should have been rewritten in OperatorToFunction"
-                    )
-                }
-            };
         }
         Expr::ScalarFunction(fun) => fun.func.display_name(&fun.args),
         Expr::WindowFunction(WindowFunction {

--- a/datafusion/core/tests/expr_api/mod.rs
+++ b/datafusion/core/tests/expr_api/mod.rs
@@ -21,6 +21,8 @@ use arrow_array::{ArrayRef, RecordBatch, StringArray, StructArray};
 use arrow_schema::{DataType, Field};
 use datafusion::prelude::*;
 use datafusion_common::DFSchema;
+use datafusion_functions::core::expr_ext::FieldAccessor;
+use datafusion_functions_array::expr_ext::{IndexAccessor, SliceAccessor};
 /// Tests of using and evaluating `Expr`s outside the context of a LogicalPlan
 use std::sync::{Arc, OnceLock};
 
@@ -61,7 +63,7 @@ fn test_eq_with_coercion() {
 #[test]
 fn test_get_field() {
     evaluate_expr_test(
-        get_field(col("props"), lit("a")),
+        col("props").field("a"),
         vec![
             "+------------+",
             "| expr       |",
@@ -77,7 +79,8 @@ fn test_get_field() {
 #[test]
 fn test_nested_get_field() {
     evaluate_expr_test(
-        get_field(col("props"), lit("a"))
+        col("props")
+            .field("a")
             .eq(lit("2021-02-02"))
             .or(col("id").eq(lit(1))),
         vec![
@@ -95,7 +98,7 @@ fn test_nested_get_field() {
 #[test]
 fn test_list() {
     evaluate_expr_test(
-        array_element(col("list"), lit(1i64)),
+        col("list").index(lit(1i64)),
         vec![
             "+------+", "| expr |", "+------+", "| one  |", "| two  |", "| five |",
             "+------+",
@@ -106,7 +109,7 @@ fn test_list() {
 #[test]
 fn test_list_range() {
     evaluate_expr_test(
-        array_slice(col("list"), lit(1i64), lit(2i64), None),
+        col("list").range(lit(1i64), lit(2i64)),
         vec![
             "+--------------+",
             "| expr         |",

--- a/datafusion/core/tests/optimizer_integration.rs
+++ b/datafusion/core/tests/optimizer_integration.rs
@@ -23,11 +23,19 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef, TimeUnit};
+use arrow_schema::{Fields, SchemaBuilder};
 use datafusion_common::config::ConfigOptions;
-use datafusion_common::{plan_err, Result};
-use datafusion_expr::{AggregateUDF, LogicalPlan, ScalarUDF, TableSource, WindowUDF};
+use datafusion_common::tree_node::{TransformedResult, TreeNode};
+use datafusion_common::{plan_err, DFSchema, Result, ScalarValue};
+use datafusion_expr::interval_arithmetic::{Interval, NullableInterval};
+use datafusion_expr::{
+    col, lit, AggregateUDF, BinaryExpr, Expr, ExprSchemable, LogicalPlan, Operator,
+    ScalarUDF, TableSource, WindowUDF,
+};
+use datafusion_functions::core::expr_ext::FieldAccessor;
 use datafusion_optimizer::analyzer::Analyzer;
 use datafusion_optimizer::optimizer::Optimizer;
+use datafusion_optimizer::simplify_expressions::GuaranteeRewriter;
 use datafusion_optimizer::{OptimizerConfig, OptimizerContext};
 use datafusion_sql::planner::{ContextProvider, SqlToRel};
 use datafusion_sql::sqlparser::ast::Statement;
@@ -231,5 +239,122 @@ impl TableSource for MyTableSource {
 
     fn schema(&self) -> SchemaRef {
         self.schema.clone()
+    }
+}
+
+#[test]
+fn test_nested_schema_nullability() {
+    let mut builder = SchemaBuilder::new();
+    builder.push(Field::new("foo", DataType::Int32, true));
+    builder.push(Field::new(
+        "parent",
+        DataType::Struct(Fields::from(vec![Field::new(
+            "child",
+            DataType::Int64,
+            false,
+        )])),
+        true,
+    ));
+    let schema = builder.finish();
+
+    let dfschema = DFSchema::from_field_specific_qualified_schema(
+        vec![Some("table_name".into()), None],
+        &Arc::new(schema),
+    )
+    .unwrap();
+
+    let expr = col("parent").field("child");
+    assert!(expr.nullable(&dfschema).unwrap());
+}
+
+#[test]
+fn test_inequalities_non_null_bounded() {
+    let guarantees = vec![
+        // x ∈ [1, 3] (not null)
+        (
+            col("x"),
+            NullableInterval::NotNull {
+                values: Interval::make(Some(1_i32), Some(3_i32)).unwrap(),
+            },
+        ),
+        // s.y ∈ [1, 3] (not null)
+        (
+            col("s").field("y"),
+            NullableInterval::NotNull {
+                values: Interval::make(Some(1_i32), Some(3_i32)).unwrap(),
+            },
+        ),
+    ];
+
+    let mut rewriter = GuaranteeRewriter::new(guarantees.iter());
+
+    // (original_expr, expected_simplification)
+    let simplified_cases = &[
+        (col("x").lt(lit(0)), false),
+        (col("s").field("y").lt(lit(0)), false),
+        (col("x").lt_eq(lit(3)), true),
+        (col("x").gt(lit(3)), false),
+        (col("x").gt(lit(0)), true),
+        (col("x").eq(lit(0)), false),
+        (col("x").not_eq(lit(0)), true),
+        (col("x").between(lit(0), lit(5)), true),
+        (col("x").between(lit(5), lit(10)), false),
+        (col("x").not_between(lit(0), lit(5)), false),
+        (col("x").not_between(lit(5), lit(10)), true),
+        (
+            Expr::BinaryExpr(BinaryExpr {
+                left: Box::new(col("x")),
+                op: Operator::IsDistinctFrom,
+                right: Box::new(lit(ScalarValue::Null)),
+            }),
+            true,
+        ),
+        (
+            Expr::BinaryExpr(BinaryExpr {
+                left: Box::new(col("x")),
+                op: Operator::IsDistinctFrom,
+                right: Box::new(lit(5)),
+            }),
+            true,
+        ),
+    ];
+
+    validate_simplified_cases(&mut rewriter, simplified_cases);
+
+    let unchanged_cases = &[
+        col("x").gt(lit(2)),
+        col("x").lt_eq(lit(2)),
+        col("x").eq(lit(2)),
+        col("x").not_eq(lit(2)),
+        col("x").between(lit(3), lit(5)),
+        col("x").not_between(lit(3), lit(10)),
+    ];
+
+    validate_unchanged_cases(&mut rewriter, unchanged_cases);
+}
+
+fn validate_simplified_cases<T>(rewriter: &mut GuaranteeRewriter, cases: &[(Expr, T)])
+where
+    ScalarValue: From<T>,
+    T: Clone,
+{
+    for (expr, expected_value) in cases {
+        let output = expr.clone().rewrite(rewriter).data().unwrap();
+        let expected = lit(ScalarValue::from(expected_value.clone()));
+        assert_eq!(
+            output, expected,
+            "{} simplified to {}, but expected {}",
+            expr, output, expected
+        );
+    }
+}
+fn validate_unchanged_cases(rewriter: &mut GuaranteeRewriter, cases: &[Expr]) {
+    for expr in cases {
+        let output = expr.clone().rewrite(rewriter).data().unwrap();
+        assert_eq!(
+            &output, expr,
+            "{} was simplified to {}, but expected it to be unchanged",
+            expr, output
+        );
     }
 }

--- a/datafusion/expr/src/expr.rs
+++ b/datafusion/expr/src/expr.rs
@@ -143,9 +143,6 @@ pub enum Expr {
     IsNotUnknown(Box<Expr>),
     /// arithmetic negation of an expression, the operand must be of a signed numeric data type
     Negative(Box<Expr>),
-    /// Returns the field of a [`arrow::array::ListArray`] or
-    /// [`arrow::array::StructArray`] by index or range
-    GetIndexedField(GetIndexedField),
     /// Whether an expression is between a given range.
     Between(Between),
     /// The CASE expression is similar to a series of nested if/else and there are two forms that
@@ -887,7 +884,6 @@ impl Expr {
             Expr::Column(..) => "Column",
             Expr::OuterReferenceColumn(_, _) => "Outer",
             Expr::Exists { .. } => "Exists",
-            Expr::GetIndexedField { .. } => "GetIndexedField",
             Expr::GroupingSet(..) => "GroupingSet",
             Expr::InList { .. } => "InList",
             Expr::InSubquery(..) => "InSubquery",
@@ -1179,91 +1175,6 @@ impl Expr {
         ))
     }
 
-    /// Return access to the named field. Example `expr["name"]`
-    ///
-    /// ## Access field "my_field" from column "c1"
-    ///
-    /// For example if column "c1" holds documents like this
-    ///
-    /// ```json
-    /// {
-    ///   "my_field": 123.34,
-    ///   "other_field": "Boston",
-    /// }
-    /// ```
-    ///
-    /// You can access column "my_field" with
-    ///
-    /// ```
-    /// # use datafusion_expr::{col};
-    /// let expr = col("c1")
-    ///    .field("my_field");
-    /// assert_eq!(expr.display_name().unwrap(), "c1[my_field]");
-    /// ```
-    pub fn field(self, name: impl Into<String>) -> Self {
-        Expr::GetIndexedField(GetIndexedField {
-            expr: Box::new(self),
-            field: GetFieldAccess::NamedStructField {
-                name: ScalarValue::from(name.into()),
-            },
-        })
-    }
-
-    /// Return access to the element field. Example `expr["name"]`
-    ///
-    /// ## Example Access element 2 from column "c1"
-    ///
-    /// For example if column "c1" holds documents like this
-    ///
-    /// ```json
-    /// [10, 20, 30, 40]
-    /// ```
-    ///
-    /// You can access the value "30" with
-    ///
-    /// ```
-    /// # use datafusion_expr::{lit, col, Expr};
-    /// let expr = col("c1")
-    ///    .index(lit(3));
-    /// assert_eq!(expr.display_name().unwrap(), "c1[Int32(3)]");
-    /// ```
-    pub fn index(self, key: Expr) -> Self {
-        Expr::GetIndexedField(GetIndexedField {
-            expr: Box::new(self),
-            field: GetFieldAccess::ListIndex { key: Box::new(key) },
-        })
-    }
-
-    /// Return elements between `1` based `start` and `stop`, for
-    /// example `expr[1:3]`
-    ///
-    /// ## Example: Access element 2, 3, 4 from column "c1"
-    ///
-    /// For example if column "c1" holds documents like this
-    ///
-    /// ```json
-    /// [10, 20, 30, 40]
-    /// ```
-    ///
-    /// You can access the value `[20, 30, 40]` with
-    ///
-    /// ```
-    /// # use datafusion_expr::{lit, col};
-    /// let expr = col("c1")
-    ///    .range(lit(2), lit(4));
-    /// assert_eq!(expr.display_name().unwrap(), "c1[Int32(2):Int32(4):Int64(1)]");
-    /// ```
-    pub fn range(self, start: Expr, stop: Expr) -> Self {
-        Expr::GetIndexedField(GetIndexedField {
-            expr: Box::new(self),
-            field: GetFieldAccess::ListRange {
-                start: Box::new(start),
-                stop: Box::new(stop),
-                stride: Box::new(Expr::Literal(ScalarValue::Int64(Some(1)))),
-            },
-        })
-    }
-
     #[deprecated(since = "39.0.0", note = "use try_as_col instead")]
     pub fn try_into_col(&self) -> Result<Column> {
         match self {
@@ -1361,7 +1272,6 @@ impl Expr {
             | Expr::Cast(..)
             | Expr::Column(..)
             | Expr::Exists(..)
-            | Expr::GetIndexedField(..)
             | Expr::GroupingSet(..)
             | Expr::InList(..)
             | Expr::InSubquery(..)
@@ -1610,19 +1520,6 @@ impl fmt::Display for Expr {
                 Some(qualifier) => write!(f, "{qualifier}.*"),
                 None => write!(f, "*"),
             },
-            Expr::GetIndexedField(GetIndexedField { field, expr }) => match field {
-                GetFieldAccess::NamedStructField { name } => {
-                    write!(f, "({expr})[{name}]")
-                }
-                GetFieldAccess::ListIndex { key } => write!(f, "({expr})[{key}]"),
-                GetFieldAccess::ListRange {
-                    start,
-                    stop,
-                    stride,
-                } => {
-                    write!(f, "({expr})[{start}:{stop}:{stride}]")
-                }
-            },
             Expr::GroupingSet(grouping_sets) => match grouping_sets {
                 GroupingSet::Rollup(exprs) => {
                     // ROLLUP (c0, c1, c2)
@@ -1826,30 +1723,6 @@ fn write_name<W: Write>(w: &mut W, e: &Expr) -> Result<()> {
         Expr::InSubquery(InSubquery { negated: false, .. }) => w.write_str("IN")?,
         Expr::ScalarSubquery(subquery) => {
             w.write_str(subquery.subquery.schema().field(0).name().as_str())?;
-        }
-        Expr::GetIndexedField(GetIndexedField { expr, field }) => {
-            write_name(w, expr)?;
-            match field {
-                GetFieldAccess::NamedStructField { name } => write!(w, "[{name}]")?,
-                GetFieldAccess::ListIndex { key } => {
-                    w.write_str("[")?;
-                    write_name(w, key)?;
-                    w.write_str("]")?;
-                }
-                GetFieldAccess::ListRange {
-                    start,
-                    stop,
-                    stride,
-                } => {
-                    w.write_str("[")?;
-                    write_name(w, start)?;
-                    w.write_str(":")?;
-                    write_name(w, stop)?;
-                    w.write_str(":")?;
-                    write_name(w, stride)?;
-                    w.write_str("]")?;
-                }
-            }
         }
         Expr::Unnest(Unnest { expr }) => {
             w.write_str("unnest(")?;

--- a/datafusion/expr/src/tree_node.rs
+++ b/datafusion/expr/src/tree_node.rs
@@ -19,10 +19,10 @@
 
 use crate::expr::{
     AggregateFunction, AggregateFunctionDefinition, Alias, Between, BinaryExpr, Case,
-    Cast, GetIndexedField, GroupingSet, InList, InSubquery, Like, Placeholder,
-    ScalarFunction, Sort, TryCast, Unnest, WindowFunction,
+    Cast, GroupingSet, InList, InSubquery, Like, Placeholder, ScalarFunction, Sort,
+    TryCast, Unnest, WindowFunction,
 };
-use crate::{Expr, GetFieldAccess};
+use crate::Expr;
 
 use datafusion_common::tree_node::{
     Transformed, TreeNode, TreeNodeIterator, TreeNodeRecursion,
@@ -51,16 +51,6 @@ impl TreeNode for Expr {
             | Expr::TryCast(TryCast { expr, .. })
             | Expr::Sort(Sort { expr, .. })
             | Expr::InSubquery(InSubquery{ expr, .. }) => vec![expr.as_ref()],
-            Expr::GetIndexedField(GetIndexedField { expr, field }) => {
-                let expr = expr.as_ref();
-                match field {
-                    GetFieldAccess::ListIndex {key} => vec![key.as_ref(), expr],
-                    GetFieldAccess::ListRange {start, stop, stride} => {
-                        vec![start.as_ref(), stop.as_ref(),stride.as_ref(), expr]
-                    }
-                    GetFieldAccess::NamedStructField { .. } => vec![expr],
-                }
-            }
             Expr::GroupingSet(GroupingSet::Rollup(exprs))
             | Expr::GroupingSet(GroupingSet::Cube(exprs)) => exprs.iter().collect(),
             Expr::ScalarFunction (ScalarFunction{ args, .. } )  => {
@@ -374,11 +364,6 @@ impl TreeNode for Expr {
             .update_data(|(new_expr, new_list)| {
                 Expr::InList(InList::new(new_expr, new_list, negated))
             }),
-            Expr::GetIndexedField(GetIndexedField { expr, field }) => {
-                transform_box(expr, &mut f)?.update_data(|be| {
-                    Expr::GetIndexedField(GetIndexedField::new(be, field))
-                })
-            }
         })
     }
 }

--- a/datafusion/expr/src/utils.rs
+++ b/datafusion/expr/src/utils.rs
@@ -302,7 +302,6 @@ pub fn expr_to_columns(expr: &Expr, accum: &mut HashSet<Column>) -> Result<()> {
             | Expr::InSubquery(_)
             | Expr::ScalarSubquery(_)
             | Expr::Wildcard { .. }
-            | Expr::GetIndexedField { .. }
             | Expr::Placeholder(_)
             | Expr::OuterReferenceColumn { .. } => {}
         }

--- a/datafusion/functions-array/src/expr_ext.rs
+++ b/datafusion/functions-array/src/expr_ext.rs
@@ -1,0 +1,102 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Extension methods for Expr.
+
+use datafusion_expr::Expr;
+
+use crate::extract::{array_element, array_slice};
+
+/// Return access to the element field. Example `expr["name"]`
+///
+/// ## Example Access element 2 from column "c1"
+///
+/// For example if column "c1" holds documents like this
+///
+/// ```json
+/// [10, 20, 30, 40]
+/// ```
+///
+/// You can access the value "30" with
+///
+/// ```
+/// # use datafusion_expr::{lit, col, Expr};
+/// # use datafusion_functions_array::expr_ext::IndexAccessor;
+/// let expr = col("c1")
+///    .index(lit(3));
+/// assert_eq!(expr.display_name().unwrap(), "c1[Int32(3)]");
+/// ```
+pub trait IndexAccessor {
+    fn index(self, key: Expr) -> Expr;
+}
+
+impl IndexAccessor for Expr {
+    fn index(self, key: Expr) -> Expr {
+        array_element(self, key)
+    }
+}
+
+/// Return elements between `1` based `start` and `stop`, for
+/// example `expr[1:3]`
+///
+/// ## Example: Access element 2, 3, 4 from column "c1"
+///
+/// For example if column "c1" holds documents like this
+///
+/// ```json
+/// [10, 20, 30, 40]
+/// ```
+///
+/// You can access the value `[20, 30, 40]` with
+///
+/// ```
+/// # use datafusion_expr::{lit, col};
+/// # use datafusion_functions_array::expr_ext::SliceAccessor;
+/// let expr = col("c1")
+///    .range(lit(2), lit(4));
+/// assert_eq!(expr.display_name().unwrap(), "c1[Int32(2):Int32(4)]");
+/// ```
+pub trait SliceAccessor {
+    fn range(self, start: Expr, stop: Expr) -> Expr;
+}
+
+impl SliceAccessor for Expr {
+    fn range(self, start: Expr, stop: Expr) -> Expr {
+        array_slice(self, start, stop, None)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use datafusion_expr::{col, lit};
+
+    #[test]
+    fn test_index() {
+        let expr1 = col("a").index(lit(1));
+        let expr2 = array_element(col("a"), lit(1));
+        assert_eq!(expr1, expr2);
+    }
+
+    #[test]
+    fn test_range() {
+        let expr1 = col("a").range(lit(1), lit(2));
+        let expr2 = array_slice(col("a"), lit(1), lit(2), None);
+        assert_eq!(expr1, expr2);
+    }
+}

--- a/datafusion/functions-array/src/extract.rs
+++ b/datafusion/functions-array/src/extract.rs
@@ -98,6 +98,11 @@ impl ScalarUDFImpl for ArrayElement {
         "array_element"
     }
 
+    fn display_name(&self, args: &[Expr]) -> Result<String> {
+        let args_name: Vec<String> = args.iter().map(|e| e.to_string()).collect();
+        Ok(format!("{}[{}]", args_name[0], args_name[1]))
+    }
+
     fn signature(&self) -> &Signature {
         &self.signature
     }
@@ -246,6 +251,12 @@ impl ScalarUDFImpl for ArraySlice {
     fn as_any(&self) -> &dyn Any {
         self
     }
+
+    fn display_name(&self, args: &[Expr]) -> Result<String> {
+        let args_name: Vec<String> = args.iter().map(|e| e.to_string()).collect();
+        Ok(format!("{}[{}]", args_name[0], args_name[1..].join(":")))
+    }
+
     fn name(&self) -> &str {
         "array_slice"
     }

--- a/datafusion/functions-array/src/lib.rs
+++ b/datafusion/functions-array/src/lib.rs
@@ -34,6 +34,7 @@ pub mod concat;
 pub mod dimension;
 pub mod empty;
 pub mod except;
+pub mod expr_ext;
 pub mod extract;
 pub mod flatten;
 pub mod length;

--- a/datafusion/functions/src/core/expr_ext.rs
+++ b/datafusion/functions/src/core/expr_ext.rs
@@ -1,0 +1,68 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Extension methods for Expr.
+
+use datafusion_expr::{Expr, Literal};
+
+use super::expr_fn::get_field;
+
+/// Return access to the named field. Example `expr["name"]`
+///
+/// ## Access field "my_field" from column "c1"
+///
+/// For example if column "c1" holds documents like this
+///
+/// ```json
+/// {
+///   "my_field": 123.34,
+///   "other_field": "Boston",
+/// }
+/// ```
+///
+/// You can access column "my_field" with
+///
+/// ```
+/// # use datafusion_expr::{col};
+/// # use datafusion_functions::core::expr_ext::FieldAccessor;
+/// let expr = col("c1")
+///    .field("my_field");
+/// assert_eq!(expr.display_name().unwrap(), "c1[my_field]");
+/// ```
+pub trait FieldAccessor {
+    fn field(self, name: impl Literal) -> Expr;
+}
+
+impl FieldAccessor for Expr {
+    fn field(self, name: impl Literal) -> Expr {
+        get_field(self, name)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use datafusion_expr::col;
+
+    #[test]
+    fn test_field() {
+        let expr1 = col("a").field("b");
+        let expr2 = get_field(col("a"), "b");
+        assert_eq!(expr1, expr2);
+    }
+}

--- a/datafusion/functions/src/core/mod.rs
+++ b/datafusion/functions/src/core/mod.rs
@@ -23,6 +23,7 @@ use std::sync::Arc;
 pub mod arrow_cast;
 pub mod arrowtypeof;
 pub mod coalesce;
+pub mod expr_ext;
 pub mod getfield;
 pub mod named_struct;
 pub mod nullif;

--- a/datafusion/functions/src/core/mod.rs
+++ b/datafusion/functions/src/core/mod.rs
@@ -44,7 +44,7 @@ make_udf_function!(coalesce::CoalesceFunc, COALESCE, coalesce);
 
 // Export the functions out of this package, both as expr_fn as well as a list of functions
 pub mod expr_fn {
-    use datafusion_expr::Expr;
+    use datafusion_expr::{Expr, Literal};
 
     /// returns NULL if value1 equals value2; otherwise it returns value1. This
     /// can be used to perform the inverse operation of the COALESCE expression
@@ -84,8 +84,8 @@ pub mod expr_fn {
     }
 
     /// Returns the value of the field with the given name from the struct
-    pub fn get_field(arg1: Expr, arg2: Expr) -> Expr {
-        super::get_field().call(vec![arg1, arg2])
+    pub fn get_field(arg1: Expr, field_name: impl Literal) -> Expr {
+        super::get_field().call(vec![arg1, field_name.lit()])
     }
 
     /// Returns `coalesce(args...)`, which evaluates to the value of the first expr which is not NULL

--- a/datafusion/optimizer/src/analyzer/type_coercion.rs
+++ b/datafusion/optimizer/src/analyzer/type_coercion.rs
@@ -399,7 +399,6 @@ impl<'a> TreeNodeRewriter for TypeCoercionRewriter<'a> {
             | Expr::IsNotNull(_)
             | Expr::IsNull(_)
             | Expr::Negative(_)
-            | Expr::GetIndexedField(_)
             | Expr::Cast(_)
             | Expr::TryCast(_)
             | Expr::Sort(_)

--- a/datafusion/optimizer/src/optimize_projections/mod.rs
+++ b/datafusion/optimizer/src/optimize_projections/mod.rs
@@ -1038,29 +1038,6 @@ mod tests {
     }
 
     #[test]
-    fn test_struct_field_push_down() -> Result<()> {
-        let schema = Arc::new(Schema::new(vec![
-            Field::new("a", DataType::Int64, false),
-            Field::new_struct(
-                "s",
-                vec![
-                    Field::new("x", DataType::Int64, false),
-                    Field::new("y", DataType::Int64, false),
-                ],
-                false,
-            ),
-        ]));
-
-        let table_scan = table_scan(TableReference::none(), &schema, None)?.build()?;
-        let plan = LogicalPlanBuilder::from(table_scan)
-            .project(vec![col("s").field("x")])?
-            .build()?;
-        let expected = "Projection: (?table?.s)[x]\
-        \n  TableScan: ?table? projection=[s]";
-        assert_optimized_plan_equal(plan, expected)
-    }
-
-    #[test]
     fn test_neg_push_down() -> Result<()> {
         let table_scan = test_table_scan()?;
         let plan = LogicalPlanBuilder::from(table_scan)

--- a/datafusion/optimizer/src/push_down_filter.rs
+++ b/datafusion/optimizer/src/push_down_filter.rs
@@ -247,7 +247,6 @@ fn can_evaluate_as_join_condition(predicate: &Expr) -> Result<bool> {
         | Expr::IsNotFalse(_)
         | Expr::IsNotUnknown(_)
         | Expr::Negative(_)
-        | Expr::GetIndexedField(_)
         | Expr::Between(_)
         | Expr::Case(_)
         | Expr::Cast(_)

--- a/datafusion/optimizer/src/simplify_expressions/expr_simplifier.rs
+++ b/datafusion/optimizer/src/simplify_expressions/expr_simplifier.rs
@@ -616,8 +616,7 @@ impl<'a> ConstEvaluator<'a> {
             | Expr::Case(_)
             | Expr::Cast { .. }
             | Expr::TryCast { .. }
-            | Expr::InList { .. }
-            | Expr::GetIndexedField { .. } => true,
+            | Expr::InList { .. } => true,
         }
     }
 

--- a/datafusion/optimizer/src/simplify_expressions/mod.rs
+++ b/datafusion/optimizer/src/simplify_expressions/mod.rs
@@ -30,3 +30,6 @@ pub use datafusion_expr::simplify::{SimplifyContext, SimplifyInfo};
 
 pub use expr_simplifier::*;
 pub use simplify_exprs::*;
+
+// Export for test in datafusion/core/tests/optimizer_integration.rs
+pub use guarantees::GuaranteeRewriter;

--- a/datafusion/physical-expr/src/planner.rs
+++ b/datafusion/physical-expr/src/planner.rs
@@ -20,16 +20,13 @@ use std::sync::Arc;
 use arrow::datatypes::Schema;
 
 use datafusion_common::{
-    exec_err, internal_err, not_impl_err, plan_err, DFSchema, Result, ScalarValue,
+    exec_err, not_impl_err, plan_err, DFSchema, Result, ScalarValue,
 };
 use datafusion_expr::execution_props::ExecutionProps;
 use datafusion_expr::expr::{Alias, Cast, InList, ScalarFunction};
 use datafusion_expr::var_provider::is_system_variables;
 use datafusion_expr::var_provider::VarType;
-use datafusion_expr::{
-    binary_expr, Between, BinaryExpr, Expr, GetFieldAccess, GetIndexedField, Like,
-    Operator, TryCast,
-};
+use datafusion_expr::{binary_expr, Between, BinaryExpr, Expr, Like, Operator, TryCast};
 
 use crate::scalar_function;
 use crate::{
@@ -287,24 +284,6 @@ pub fn create_physical_expr(
             input_dfschema,
             execution_props,
         )?),
-        Expr::GetIndexedField(GetIndexedField { expr: _, field }) => match field {
-            GetFieldAccess::NamedStructField { name: _ } => {
-                internal_err!(
-                    "NamedStructField should be rewritten in OperatorToFunction"
-                )
-            }
-            GetFieldAccess::ListIndex { key: _ } => {
-                internal_err!("ListIndex should be rewritten in OperatorToFunction")
-            }
-            GetFieldAccess::ListRange {
-                start: _,
-                stop: _,
-                stride: _,
-            } => {
-                internal_err!("ListRange should be rewritten in OperatorToFunction")
-            }
-        },
-
         Expr::ScalarFunction(ScalarFunction { func, args }) => {
             let physical_args =
                 create_physical_exprs(args, input_dfschema, execution_props)?;

--- a/datafusion/proto/proto/datafusion.proto
+++ b/datafusion/proto/proto/datafusion.proto
@@ -397,7 +397,7 @@ message LogicalExprNode {
     // Scalar UDF expressions
     ScalarUDFExprNode scalar_udf_expr = 20;
 
-    GetIndexedField get_indexed_field = 21;
+    // GetIndexedField get_indexed_field = 21;
 
     GroupingSetNode grouping_set = 22;
 

--- a/datafusion/proto/src/generated/pbjson.rs
+++ b/datafusion/proto/src/generated/pbjson.rs
@@ -13763,9 +13763,6 @@ impl serde::Serialize for LogicalExprNode {
                 logical_expr_node::ExprType::ScalarUdfExpr(v) => {
                     struct_ser.serialize_field("scalarUdfExpr", v)?;
                 }
-                logical_expr_node::ExprType::GetIndexedField(v) => {
-                    struct_ser.serialize_field("getIndexedField", v)?;
-                }
                 logical_expr_node::ExprType::GroupingSet(v) => {
                     struct_ser.serialize_field("groupingSet", v)?;
                 }
@@ -13850,8 +13847,6 @@ impl<'de> serde::Deserialize<'de> for LogicalExprNode {
             "aggregateUdfExpr",
             "scalar_udf_expr",
             "scalarUdfExpr",
-            "get_indexed_field",
-            "getIndexedField",
             "grouping_set",
             "groupingSet",
             "cube",
@@ -13897,7 +13892,6 @@ impl<'de> serde::Deserialize<'de> for LogicalExprNode {
             WindowExpr,
             AggregateUdfExpr,
             ScalarUdfExpr,
-            GetIndexedField,
             GroupingSet,
             Cube,
             Rollup,
@@ -13952,7 +13946,6 @@ impl<'de> serde::Deserialize<'de> for LogicalExprNode {
                             "windowExpr" | "window_expr" => Ok(GeneratedField::WindowExpr),
                             "aggregateUdfExpr" | "aggregate_udf_expr" => Ok(GeneratedField::AggregateUdfExpr),
                             "scalarUdfExpr" | "scalar_udf_expr" => Ok(GeneratedField::ScalarUdfExpr),
-                            "getIndexedField" | "get_indexed_field" => Ok(GeneratedField::GetIndexedField),
                             "groupingSet" | "grouping_set" => Ok(GeneratedField::GroupingSet),
                             "cube" => Ok(GeneratedField::Cube),
                             "rollup" => Ok(GeneratedField::Rollup),
@@ -14120,13 +14113,6 @@ impl<'de> serde::Deserialize<'de> for LogicalExprNode {
                                 return Err(serde::de::Error::duplicate_field("scalarUdfExpr"));
                             }
                             expr_type__ = map_.next_value::<::std::option::Option<_>>()?.map(logical_expr_node::ExprType::ScalarUdfExpr)
-;
-                        }
-                        GeneratedField::GetIndexedField => {
-                            if expr_type__.is_some() {
-                                return Err(serde::de::Error::duplicate_field("getIndexedField"));
-                            }
-                            expr_type__ = map_.next_value::<::std::option::Option<_>>()?.map(logical_expr_node::ExprType::GetIndexedField)
 ;
                         }
                         GeneratedField::GroupingSet => {

--- a/datafusion/proto/src/generated/prost.rs
+++ b/datafusion/proto/src/generated/prost.rs
@@ -566,7 +566,7 @@ pub struct SubqueryAliasNode {
 pub struct LogicalExprNode {
     #[prost(
         oneof = "logical_expr_node::ExprType",
-        tags = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35"
+        tags = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 17, 18, 19, 20, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35"
     )]
     pub expr_type: ::core::option::Option<logical_expr_node::ExprType>,
 }
@@ -622,8 +622,6 @@ pub mod logical_expr_node {
         /// Scalar UDF expressions
         #[prost(message, tag = "20")]
         ScalarUdfExpr(super::ScalarUdfExprNode),
-        #[prost(message, tag = "21")]
-        GetIndexedField(::prost::alloc::boxed::Box<super::GetIndexedField>),
         #[prost(message, tag = "22")]
         GroupingSet(super::GroupingSetNode),
         #[prost(message, tag = "23")]
@@ -701,24 +699,24 @@ pub struct NamedStructField {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListIndex {
-    #[prost(message, optional, boxed, tag = "1")]
-    pub key: ::core::option::Option<::prost::alloc::boxed::Box<LogicalExprNode>>,
+    #[prost(message, optional, tag = "1")]
+    pub key: ::core::option::Option<LogicalExprNode>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListRange {
-    #[prost(message, optional, boxed, tag = "1")]
-    pub start: ::core::option::Option<::prost::alloc::boxed::Box<LogicalExprNode>>,
-    #[prost(message, optional, boxed, tag = "2")]
-    pub stop: ::core::option::Option<::prost::alloc::boxed::Box<LogicalExprNode>>,
-    #[prost(message, optional, boxed, tag = "3")]
-    pub stride: ::core::option::Option<::prost::alloc::boxed::Box<LogicalExprNode>>,
+    #[prost(message, optional, tag = "1")]
+    pub start: ::core::option::Option<LogicalExprNode>,
+    #[prost(message, optional, tag = "2")]
+    pub stop: ::core::option::Option<LogicalExprNode>,
+    #[prost(message, optional, tag = "3")]
+    pub stride: ::core::option::Option<LogicalExprNode>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetIndexedField {
-    #[prost(message, optional, boxed, tag = "1")]
-    pub expr: ::core::option::Option<::prost::alloc::boxed::Box<LogicalExprNode>>,
+    #[prost(message, optional, tag = "1")]
+    pub expr: ::core::option::Option<LogicalExprNode>,
     #[prost(oneof = "get_indexed_field::Field", tags = "2, 3, 4")]
     pub field: ::core::option::Option<get_indexed_field::Field>,
 }
@@ -730,9 +728,9 @@ pub mod get_indexed_field {
         #[prost(message, tag = "2")]
         NamedStructField(super::NamedStructField),
         #[prost(message, tag = "3")]
-        ListIndex(::prost::alloc::boxed::Box<super::ListIndex>),
+        ListIndex(super::ListIndex),
         #[prost(message, tag = "4")]
-        ListRange(::prost::alloc::boxed::Box<super::ListRange>),
+        ListRange(super::ListRange),
     }
 }
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/datafusion/proto/src/logical_plan/from_proto.rs
+++ b/datafusion/proto/src/logical_plan/from_proto.rs
@@ -40,7 +40,7 @@ use datafusion_expr::{
     expr::{self, InList, Sort, WindowFunction},
     logical_plan::{PlanType, StringifiedPlan},
     AggregateFunction, Between, BinaryExpr, BuiltInWindowFunction, Case, Cast, Expr,
-    GetFieldAccess, GetIndexedField, GroupingSet,
+    GroupingSet,
     GroupingSet::GroupingSets,
     JoinConstraint, JoinType, Like, Operator, TryCast, WindowFrame, WindowFrameBound,
     WindowFrameUnits,
@@ -876,63 +876,6 @@ pub fn parse_expr(
                     Expr::BinaryExpr(BinaryExpr::new(Box::new(left), op, Box::new(right)))
                 })
                 .expect("Binary expression could not be reduced to a single expression."))
-        }
-        ExprType::GetIndexedField(get_indexed_field) => {
-            let expr = parse_required_expr(
-                get_indexed_field.expr.as_deref(),
-                registry,
-                "expr",
-                codec,
-            )?;
-            let field = match &get_indexed_field.field {
-                Some(protobuf::get_indexed_field::Field::NamedStructField(
-                    named_struct_field,
-                )) => GetFieldAccess::NamedStructField {
-                    name: named_struct_field
-                        .name
-                        .as_ref()
-                        .ok_or_else(|| Error::required("value"))?
-                        .try_into()?,
-                },
-                Some(protobuf::get_indexed_field::Field::ListIndex(list_index)) => {
-                    GetFieldAccess::ListIndex {
-                        key: Box::new(parse_required_expr(
-                            list_index.key.as_deref(),
-                            registry,
-                            "key",
-                            codec,
-                        )?),
-                    }
-                }
-                Some(protobuf::get_indexed_field::Field::ListRange(list_range)) => {
-                    GetFieldAccess::ListRange {
-                        start: Box::new(parse_required_expr(
-                            list_range.start.as_deref(),
-                            registry,
-                            "start",
-                            codec,
-                        )?),
-                        stop: Box::new(parse_required_expr(
-                            list_range.stop.as_deref(),
-                            registry,
-                            "stop",
-                            codec,
-                        )?),
-                        stride: Box::new(parse_required_expr(
-                            list_range.stride.as_deref(),
-                            registry,
-                            "stride",
-                            codec,
-                        )?),
-                    }
-                }
-                None => return Err(proto_error("Field must not be None")),
-            };
-
-            Ok(Expr::GetIndexedField(GetIndexedField::new(
-                Box::new(expr),
-                field,
-            )))
         }
         ExprType::Column(column) => Ok(Expr::Column(column.into())),
         ExprType::Literal(literal) => {

--- a/datafusion/sql/src/unparser/expr.rs
+++ b/datafusion/sql/src/unparser/expr.rs
@@ -25,7 +25,7 @@ use datafusion_common::{
     ScalarValue,
 };
 use datafusion_expr::{
-    expr::{Alias, Exists, InList, ScalarFunction, Sort, WindowFunction},
+    expr::{Alias, Exists, InList, ScalarFunction, Sort, TryCast, WindowFunction},
     Between, BinaryExpr, Case, Cast, Expr, Like, Operator,
 };
 use sqlparser::ast::{
@@ -393,10 +393,14 @@ impl Unparser<'_> {
             }
             Expr::IsNull(_) => not_impl_err!("Unsupported Expr conversion: {expr:?}"),
             Expr::IsNotFalse(_) => not_impl_err!("Unsupported Expr conversion: {expr:?}"),
-            Expr::GetIndexedField(_) => {
-                not_impl_err!("Unsupported Expr conversion: {expr:?}")
+            Expr::TryCast(TryCast { expr, data_type }) => {
+                let inner_expr = self.expr_to_sql(expr)?;
+                Ok(ast::Expr::TryCast {
+                    expr: Box::new(inner_expr),
+                    data_type: self.arrow_dtype_to_ast_dtype(data_type)?,
+                    format: None,
+                })
             }
-            Expr::TryCast(_) => not_impl_err!("Unsupported Expr conversion: {expr:?}"),
             Expr::Wildcard { qualifier: _ } => {
                 not_impl_err!("Unsupported Expr conversion: {expr:?}")
             }

--- a/datafusion/sqllogictest/test_files/projection.slt
+++ b/datafusion/sqllogictest/test_files/projection.slt
@@ -233,3 +233,20 @@ DROP TABLE test;
 
 statement ok
 DROP TABLE test_simple;
+
+## projection push down with Struct
+statement ok
+create table t as values (struct(1));
+
+query TT
+explain select column1.c0 from t;
+----
+logical_plan
+01)Projection: get_field(t.column1, Utf8("c0"))
+02)--TableScan: t projection=[column1]
+physical_plan
+01)ProjectionExec: expr=[get_field(column1@0, c0) as t.column1[c0]]
+02)--MemoryExec: partitions=1, partition_sizes=[1]
+
+statement ok
+drop table t;


### PR DESCRIPTION
⚠️ This will not be merged. ⚠️ 

1. Bringing us up to datafusion to 2024-05-TBD

2. This PR is based on May 13, 2024 https://github.com/apache/datafusion/commit/b8fab5cdf418e1fba5e6012b815a5bc40c7771cc

```shell
git co -b chunchun/update-df-may-week-3 b8fab5cdf418e1fba5e6012b815a5bc40c7771cc
```

3. Applied the following patch(es):

    1. cherry picked https://github.com/apache/datafusion/pull/10568 / https://github.com/apache/datafusion/commit/3ebc31d2c26e6ff02d3cc79e5e4786d4ed029710
   
        ```shell
        commit 6ea3a01347cee336b5fac823c2aad7cb14150fe0
        Author: Jay Zhan <jayzhan211@gmail.com>
        Date:   Tue May 21 08:07:25 2024 +0800

            Remove `Expr::GetIndexedField`, replace `Expr::{field,index,range}` with `FieldAccessor`, `IndexAccessor`, and `SliceAccessor` (#10568)
        ```
