### PR TITLE
fix: fix regressions in tests

### DIFF
--- a/datafusion/common/src/utils/mod.rs
+++ b/datafusion/common/src/utils/mod.rs
@@ -693,6 +693,9 @@ pub fn transpose<T>(original: Vec<Vec<T>>) -> Vec<Vec<T>> {
 /// Computes the `skip` and `fetch` parameters of a single limit that would be
 /// equivalent to two consecutive limits with the given `skip`/`fetch` parameters.
 ///
+/// This function assumes that the child skip is applied first, then the child fetch occurs at the
+/// same time as the parent skip.
+///
 /// There are multiple cases to consider:
 ///
 /// # Case 0: Parent and child are disjoint (`child_fetch <= skip`).

--- a/datafusion/functions/benches/repeat.rs
+++ b/datafusion/functions/benches/repeat.rs
@@ -67,7 +67,7 @@ fn criterion_benchmark(c: &mut Criterion) {
 
         let args = create_args::<i32>(size, 32, repeat_times, true);
         group.bench_function(
-            &format!(
+            format!(
                 "repeat_string_view [size={}, repeat_times={}]",
                 size, repeat_times
             ),
@@ -76,7 +76,7 @@ fn criterion_benchmark(c: &mut Criterion) {
 
         let args = create_args::<i32>(size, 32, repeat_times, false);
         group.bench_function(
-            &format!(
+            format!(
                 "repeat_string [size={}, repeat_times={}]",
                 size, repeat_times
             ),
@@ -85,7 +85,7 @@ fn criterion_benchmark(c: &mut Criterion) {
 
         let args = create_args::<i64>(size, 32, repeat_times, false);
         group.bench_function(
-            &format!(
+            format!(
                 "repeat_large_string [size={}, repeat_times={}]",
                 size, repeat_times
             ),
@@ -103,7 +103,7 @@ fn criterion_benchmark(c: &mut Criterion) {
 
         let args = create_args::<i32>(size, 32, repeat_times, true);
         group.bench_function(
-            &format!(
+            format!(
                 "repeat_string_view [size={}, repeat_times={}]",
                 size, repeat_times
             ),
@@ -112,7 +112,7 @@ fn criterion_benchmark(c: &mut Criterion) {
 
         let args = create_args::<i32>(size, 32, repeat_times, false);
         group.bench_function(
-            &format!(
+            format!(
                 "repeat_string [size={}, repeat_times={}]",
                 size, repeat_times
             ),
@@ -121,7 +121,7 @@ fn criterion_benchmark(c: &mut Criterion) {
 
         let args = create_args::<i64>(size, 32, repeat_times, false);
         group.bench_function(
-            &format!(
+            format!(
                 "repeat_large_string [size={}, repeat_times={}]",
                 size, repeat_times
             ),

--- a/datafusion/physical-optimizer/src/limit_pushdown.rs
+++ b/datafusion/physical-optimizer/src/limit_pushdown.rs
@@ -160,7 +160,6 @@ pub fn pushdown_limit_helper(
     // If we have a non-limit operator with fetch capability, update global
     // state as necessary:
     if pushdown_plan.fetch().is_some() {
-
         // if global_state.fetch.is_none(), then there were no LimitExecs on top of the
         // pushdown_plan, so we can safely assume that whatever this plan has set as its `fetch`
         // value is already what we need, so the requirements are satisfied.
@@ -181,11 +180,7 @@ pub fn pushdown_limit_helper(
         return if global_state.skip > 0 && !global_state.satisfied {
             // There might be a case with only offset, if so add a global limit:
             global_state.satisfied = true;
-            Transformed::yes(add_global_limit(
-                pushdown_plan,
-                global_state.skip,
-                None,
-            ))
+            Transformed::yes(add_global_limit(pushdown_plan, global_state.skip, None))
         } else {
             // There's no info on offset or fetch, nothing to do:
             Transformed::no(pushdown_plan)
@@ -198,10 +193,10 @@ pub fn pushdown_limit_helper(
         if !combines_input_partitions(&pushdown_plan) {
             // We have information in the global state and the plan pushes down,
             // continue:
-            return Transformed::no(pushdown_plan)
+            return Transformed::no(pushdown_plan);
         } else if global_state.satisfied {
             // If the plan is already satisfied, do not add a limit:
-            return Transformed::no(pushdown_plan)
+            return Transformed::no(pushdown_plan);
         }
 
         if global_state.skip == 0 {
@@ -210,16 +205,12 @@ pub fn pushdown_limit_helper(
                 // fetch info to plan if possible. If not, we must add a `LimitExec`
                 // with the information from the global state.
                 global_state.satisfied = true;
-                return Transformed::yes(plan_with_fetch)
+                return Transformed::yes(plan_with_fetch);
             }
         }
 
         global_state.satisfied = true;
-        Transformed::yes(add_limit(
-            pushdown_plan,
-            global_state.skip,
-            global_fetch,
-        ))
+        Transformed::yes(add_limit(pushdown_plan, global_state.skip, global_fetch))
     } else {
         // The plan does not support push down and it is not a limit. We will need
         // to add a limit or a fetch. If the plan is already satisfied, we will try

--- a/datafusion/sqllogictest/test_files/parquet.slt
+++ b/datafusion/sqllogictest/test_files/parquet.slt
@@ -263,13 +263,13 @@ LIMIT 10;
 0 NULL Timestamp(Millisecond, Some("UTC"))
 0 2014-08-27T14:00:00Z Timestamp(Millisecond, Some("UTC"))
 0 2014-08-27T14:00:00Z Timestamp(Millisecond, Some("UTC"))
-4 2014-08-27T14:00:00Z Timestamp(Millisecond, Some("UTC"))
 0 2014-08-27T14:00:00Z Timestamp(Millisecond, Some("UTC"))
-0 2014-08-27T14:00:00Z Timestamp(Millisecond, Some("UTC"))
+12 2014-08-27T14:00:00Z Timestamp(Millisecond, Some("UTC"))
+2 2014-08-27T14:00:00Z Timestamp(Millisecond, Some("UTC"))
 0 2014-08-27T14:00:00Z Timestamp(Millisecond, Some("UTC"))
 14 2014-08-27T14:00:00Z Timestamp(Millisecond, Some("UTC"))
-0 2014-08-27T14:00:00Z Timestamp(Millisecond, Some("UTC"))
-0 2014-08-27T14:00:00Z Timestamp(Millisecond, Some("UTC"))
+5 2014-08-27T14:00:00Z Timestamp(Millisecond, Some("UTC"))
+1 2014-08-27T14:00:00Z Timestamp(Millisecond, Some("UTC"))
 
 # Test config listing_table_ignore_subdirectory:
 


### PR DESCRIPTION
Specifically, the regressions caused by 02eab80cd62e02fcb68dee8b99d63aaac680a66c

This should let us get by [this blocker](https://github.com/influxdata/influxdb_iox/issues/12102) and continue DF upgrades.

I'm just putting it here for now so I don't forget abt it and others can look at it. It needs more comments and more descriptive commit names.

Also, it still seems to affect ordering of results that are equivalent - so our tests don't pass without changes after this, but I think they'll be correct after this PR.

This also might prevent some of the optimizations that the linked commit was trying to get? I'm not certain.