### PR TITLE
chore: workaround exponential planning time bug in DF fork

### DIFF
--- a/datafusion/optimizer/src/unwrap_cast_in_comparison.rs
+++ b/datafusion/optimizer/src/unwrap_cast_in_comparison.rs
@@ -25,6 +25,7 @@ use crate::optimizer::ApplyOrder;
 use crate::{OptimizerConfig, OptimizerRule};
 
 use crate::utils::NamePreserver;
+#[allow(deprecated)]
 use arrow::datatypes::{
     DataType, TimeUnit, MAX_DECIMAL128_FOR_EACH_PRECISION,
     MIN_DECIMAL128_FOR_EACH_PRECISION,

--- a/datafusion/physical-optimizer/src/sanity_checker.rs
+++ b/datafusion/physical-optimizer/src/sanity_checker.rs
@@ -32,6 +32,8 @@ use datafusion_common::tree_node::{Transformed, TransformedResult, TreeNode};
 use datafusion_physical_expr::intervals::utils::{check_support, is_datatype_supported};
 use datafusion_physical_plan::execution_plan::{Boundedness, EmissionType};
 use datafusion_physical_plan::joins::SymmetricHashJoinExec;
+use datafusion_physical_plan::sorts::sort::SortExec;
+use datafusion_physical_plan::union::UnionExec;
 use datafusion_physical_plan::{get_plan_string, ExecutionPlanProperties};
 
 use crate::PhysicalOptimizerRule;
@@ -135,6 +137,14 @@ pub fn check_plan_sanity(
         plan.required_input_ordering(),
         plan.required_input_distribution(),
     ) {
+        // TEMP HACK WORKAROUND https://github.com/apache/datafusion/issues/11492
+        if child.as_any().downcast_ref::<UnionExec>().is_some() {
+            continue;
+        }
+        if child.as_any().downcast_ref::<SortExec>().is_some() {
+            continue;
+        }
+
         let child_eq_props = child.equivalence_properties();
         if let Some(sort_req) = sort_req {
             if !child_eq_props.ordering_satisfy_requirement(&sort_req) {

--- a/datafusion/sqllogictest/test_files/union.slt
+++ b/datafusion/sqllogictest/test_files/union.slt
@@ -539,6 +539,9 @@ physical_plan
 ########
 
 statement ok
+drop table t
+
+statement ok
 drop table t1;
 
 statement ok
@@ -778,76 +781,36 @@ select make_array(make_array(1)) x UNION ALL SELECT make_array(arrow_cast(make_a
 [[-1]]
 [[1]]
 
+###
+# Test for https://github.com/apache/datafusion/issues/11492
+###
+
+# Input data is
+# a,b,c
+# 1,2,3
+
 statement ok
-CREATE EXTERNAL TABLE aggregate_test_100 (
-  c1  VARCHAR NOT NULL,
-  c2  TINYINT NOT NULL,
-  c3  SMALLINT NOT NULL,
-  c4  SMALLINT,
-  c5  INT,
-  c6  BIGINT NOT NULL,
-  c7  SMALLINT NOT NULL,
-  c8  INT NOT NULL,
-  c9  BIGINT UNSIGNED NOT NULL,
-  c10 VARCHAR NOT NULL,
-  c11 FLOAT NOT NULL,
-  c12 DOUBLE NOT NULL,
-  c13 VARCHAR NOT NULL
+CREATE EXTERNAL TABLE t (
+  a INT,
+  b INT,
+  c INT
 )
 STORED AS CSV
-LOCATION '../../testing/data/csv/aggregate_test_100.csv'
+LOCATION '../core/tests/data/example.csv'
+WITH ORDER (a ASC)
 OPTIONS ('format.has_header' 'true');
 
-statement ok
-set datafusion.execution.batch_size = 2;
-
-# Constant value tracking across union
-query TT
-explain
-SELECT * FROM(
-(
-    SELECT * FROM aggregate_test_100 WHERE c1='a'
-)
-UNION ALL
-(
-    SELECT * FROM aggregate_test_100 WHERE c1='a'
-))
-ORDER BY c1
+query T
+SELECT (SELECT a from t ORDER BY a) UNION ALL (SELECT 'bar' as a from t) ORDER BY a;
 ----
-logical_plan
-01)Sort: aggregate_test_100.c1 ASC NULLS LAST
-02)--Union
-03)----Filter: aggregate_test_100.c1 = Utf8("a")
-04)------TableScan: aggregate_test_100 projection=[c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13], partial_filters=[aggregate_test_100.c1 = Utf8("a")]
-05)----Filter: aggregate_test_100.c1 = Utf8("a")
-06)------TableScan: aggregate_test_100 projection=[c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13], partial_filters=[aggregate_test_100.c1 = Utf8("a")]
-physical_plan
-01)CoalescePartitionsExec
-02)--UnionExec
-03)----CoalesceBatchesExec: target_batch_size=2
-04)------FilterExec: c1@0 = a
-05)--------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
-06)----------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/testing/data/csv/aggregate_test_100.csv]]}, projection=[c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13], has_header=true
-07)----CoalesceBatchesExec: target_batch_size=2
-08)------FilterExec: c1@0 = a
-09)--------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
-10)----------CsvExec: file_groups={1 group: [[WORKSPACE_ROOT/testing/data/csv/aggregate_test_100.csv]]}, projection=[c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13], has_header=true
+1
+bar
 
-# Clean up after the test
-statement ok
-drop table aggregate_test_100;
-
-# test for https://github.com/apache/datafusion/issues/14352
-query TB rowsort
-SELECT
-    a,
-    a IS NOT NULL
-FROM (
-    -- second column, even though it's not selected, was necessary to reproduce the bug linked above
-    SELECT 'foo' AS a, 3 AS b
-    UNION ALL
-    SELECT NULL AS a, 4 AS b
-)
+query I
+SELECT (SELECT a from t ORDER BY a) UNION ALL (SELECT NULL as a from t) ORDER BY a;
 ----
-NULL false
-foo true
+1
+NULL 
+
+statement ok
+drop table t


### PR DESCRIPTION
Targets https://github.com/influxdata/influxdb_iox/pull/13448


As @wiedld  mentions in https://github.com/influxdata/arrow-datafusion/pull/54#issue-2814329377:

The upstream code has been changed so our previous revert can't be applied cleanly

This PR reverts the behavior with a different patch (copy/paste the old code from https://github.com/apache/datafusion/pull/12562)

Locally when I run the following command without this fix, it fails (timesout)

```shell
$ RUST_BACKTRACE=1 TEST_INFLUXDB_JDBC=true TEST_INTEGRATION=1 TEST_INFLUXDB_IOX_CATALOG_DSN=postgresql://postgres@localhost:5432/postgres cargo test --test  end_to_end --  read_filter_many_tables
```

When I have this fix it passes

```
running 1 test
test end_to_end_cases::querier::influxrpc::read_filter::read_filter_many_tables ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 478 filtered out; finished in 9.67s
```
