### PR TITLE
Bump runner to ubuntu-latest

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -41,7 +41,7 @@ on:
 jobs:
   # Check license header
   license-header-check:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     name: Check License Header
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
20.04 is being EOL'd and will be disabled as of 1 Apr 25. Bumping Ubuntu version to `-latest` aligns with the rest of the runner workflow and should not be disruptive.

This does not impact any df functionality.
