### PR TITLE
test: Demonstrate EnforceDistribution and EnforceSorting behavior on the latest DF branch.

### DIFF
--- a/datafusion/core/tests/physical_optimizer/enforce_distribution.rs
+++ b/datafusion/core/tests/physical_optimizer/enforce_distribution.rs
@@ -263,7 +263,7 @@ fn csv_exec_multiple_sorted(output_ordering: Vec<LexOrdering>) -> Arc<DataSource
     .new_exec()
 }
 
-fn projection_exec_with_alias(
+pub(crate) fn projection_exec_with_alias(
     input: Arc<dyn ExecutionPlan>,
     alias_pairs: Vec<(String, String)>,
 ) -> Arc<dyn ExecutionPlan> {

--- a/datafusion/core/tests/physical_optimizer/sanity_checker.rs
+++ b/datafusion/core/tests/physical_optimizer/sanity_checker.rs
@@ -388,13 +388,21 @@ fn create_test_schema2() -> SchemaRef {
 }
 
 /// Check if sanity checker should accept or reject plans.
-fn assert_sanity_check(plan: &Arc<dyn ExecutionPlan>, is_sane: bool) {
+pub(crate) fn assert_sanity_check(plan: &Arc<dyn ExecutionPlan>, is_sane: bool) {
     let sanity_checker = SanityCheckPlan::new();
     let opts = ConfigOptions::default();
-    assert_eq!(
-        sanity_checker.optimize(plan.clone(), &opts).is_ok(),
-        is_sane
-    );
+    let res = sanity_checker
+        .optimize(plan.clone(), &opts)
+        .map_err(|e| e.to_string());
+    assert_eq!(res.is_ok(), is_sane, "SanityCheck returned {:?}", res);
+}
+
+/// Assert reason for sanity check failure.
+pub(crate) fn assert_sanity_check_err(plan: &Arc<dyn ExecutionPlan>, err: &str) {
+    let sanity_checker = SanityCheckPlan::new();
+    let opts = ConfigOptions::default();
+    let error = sanity_checker.optimize(plan.clone(), &opts).unwrap_err();
+    assert!(error.message().contains(err));
 }
 
 /// Check if the plan we created is as expected by comparing the plan


### PR DESCRIPTION
Follow up to https://github.com/influxdata/arrow-datafusion/pull/58, which demonstrates:
* (behavior): the output of EnforceDistribution
* (bug): how this output was then made invalid in the subsequent EnforceSorting.

In this PR, we tried to recreate on the latest apache main branch. It was found that:
* (behavior): the output of EnforceDistribution is different
* (bug): bug still occurs. If we provide the same valid plan, the EnforceSorting makes it invalid.

## Followups:
Upstream/apache fix is going to focus on the EnforceSorting bug.
Separately, going to make some of the test setup cleanups from the EnforceDistribution learnings.