### PR TITLE
Backport change to avoid debug symbols in ci builds 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -197,6 +197,7 @@ rpath = false
 strip = false            # Retain debug info for flamegraphs
 
 [profile.ci]
+debug = false
 inherits = "dev"
 incremental = false
 


### PR DESCRIPTION
# Rationale
The CI in patched version of DataFusion 49.0.2  from @erratic-pattern  in this PR is failing:
 - https://github.com/influxdata/arrow-datafusion/pull/76

I believe we fixed something similar upstream in later revisions, so let's backport that patch to our fork to see if we can get a clean CI run

# Changes
* `git cherry-pick`: 58018126eef070141f9073195cedd26d305c8446 / https://github.com/apache/datafusion/pull/17795 into our fork

Note that merging this PR will update https://github.com/influxdata/arrow-datafusion/pull/76

