### PR TITLE
fix(physical-expr): stack overflow protection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2489,6 +2489,7 @@ dependencies = [
  "paste",
  "petgraph 0.8.3",
  "rand 0.9.2",
+ "recursive",
  "rstest",
 ]
 

--- a/datafusion/physical-expr/Cargo.toml
+++ b/datafusion/physical-expr/Cargo.toml
@@ -55,6 +55,7 @@ itertools = { workspace = true, features = ["use_std"] }
 parking_lot = { workspace = true }
 paste = "^1.0"
 petgraph = "0.8.3"
+recursive = { workspace = true }
 
 [dev-dependencies]
 arrow = { workspace = true, features = ["test_utils"] }

--- a/datafusion/physical-expr/src/planner.rs
+++ b/datafusion/physical-expr/src/planner.rs
@@ -105,6 +105,7 @@ use datafusion_expr::{
 /// * `e` - The logical expression
 /// * `input_dfschema` - The DataFusion schema for the input, used to resolve `Column` references
 ///   to qualified or unqualified fields by name.
+#[recursive::recursive]
 pub fn create_physical_expr(
     e: &Expr,
     input_dfschema: &DFSchema,


### PR DESCRIPTION
Add the recursive annotation to create_physical_expr to protect from a stack overflow occurring due to some pathological query expressions.
