### PR TITLE
fix: prevent LEAD/LAG IGNORE NULLS panic without null bitmap (#23706)

### DIFF
--- a/datafusion/functions-window/src/lead_lag.rs
+++ b/datafusion/functions-window/src/lead_lag.rs
@@ -428,8 +428,12 @@ fn evaluate_all_with_ignore_null(
     default_value: &ScalarValue,
     is_lag: bool,
 ) -> Result<ArrayRef, DataFusionError> {
-    let valid_indices: Vec<usize> =
-        array.nulls().unwrap().valid_indices().collect::<Vec<_>>();
+    // Arrays without NULLs do not necessarily have a null bitmap.
+    let Some(nulls) = array.nulls() else {
+        return shift_with_default_value(array, offset, default_value);
+    };
+
+    let valid_indices: Vec<usize> = nulls.valid_indices().collect::<Vec<_>>();
     let direction = !is_lag;
     let new_array_results: Result<Vec<_>, DataFusionError> = (0..array.len())
         .map(|id| {
@@ -826,5 +830,26 @@ mod tests {
             .iter()
             .collect::<Int32Array>(),
         )
+    }
+
+    #[test]
+    fn test_ignore_nulls_without_null_bitmap() -> Result<()> {
+        let input = Int32Array::from(vec![1, 2, 3]);
+        assert!(input.nulls().is_none());
+        let input: ArrayRef = Arc::new(input);
+
+        for (offset, expected) in [
+            (1, Int32Array::from(vec![None, Some(1), Some(2)])),
+            (-1, Int32Array::from(vec![Some(2), Some(3), None])),
+        ] {
+            let actual = evaluate_all_with_ignore_null(
+                &input,
+                offset,
+                &ScalarValue::Int32(None),
+                offset > 0,
+            )?;
+            assert_eq!(expected, *as_int32_array(&actual)?);
+        }
+        Ok(())
     }
 }


### PR DESCRIPTION
## Rationale for this change

Arrow arrays containing no null values commonly omit the null bitmap.
The whole-partition evaluation path for `LEAD` and `LAG` with `IGNORE
NULLS` unconditionally unwrapped that optional bitmap, causing a panic
for valid non-null input arrays.

(cherry picked from commit a8d1af6b8a82ded56eb547ad698b224c1f8bf7be)

for influxdata/EAR#7049